### PR TITLE
bagel package set must come first

### DIFF
--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 package_sets:
-  - github: rock-simulation/package_set
   - github: dfki-ric/bagel_package_set
+  - github: rock-simulation/package_set
 
 layout:
   - bagel/xrock_gui_model


### PR DESCRIPTION
Related to a recent autoproj update the manifest needs to be cleaned up: `rock-simulation/package_set` depends on `dfki-ric/bagel_package_set` and is confused by it being imported another time afterwards.

The build is not fixed entirely though. Another error occurs afterwards:

    external/cpr(/opt/workspace/external/cpr): failed in build phase
        'make --jobserver-fds=7,8 -j' returned status 2
        see /opt/workspace/install/log/external/cpr-build.log for details
        last 18 lines are:

        Scanning dependencies of target cpr
        [  7%] Building CXX object cpr/CMakeFiles/cpr.dir/auth.cpp.o
        [ 14%] Building CXX object cpr/CMakeFiles/cpr.dir/cookies.cpp.o
        [ 21%] Building CXX object cpr/CMakeFiles/cpr.dir/cprtypes.cpp.o
        [ 28%] Building CXX object cpr/CMakeFiles/cpr.dir/digest.cpp.o
        [ 35%] Building CXX object cpr/CMakeFiles/cpr.dir/error.cpp.o
        [ 42%] Building CXX object cpr/CMakeFiles/cpr.dir/multipart.cpp.o
        /opt/workspace/external/cpr/cpr/error.cpp:3:10: fatal error: curl/curl.h: No such file or directory
         #include <curl/curl.h>
                  ^~~~~~~~~~~~~
        compilation terminated.
        cpr/CMakeFiles/cpr.dir/build.make:158: recipe for target 'cpr/CMakeFiles/cpr.dir/error.cpp.o' failed
        make[2]: *** [cpr/CMakeFiles/cpr.dir/error.cpp.o] Error 1
        make[2]: *** Waiting for unfinished jobs....
        CMakeFiles/Makefile2:85: recipe for target 'cpr/CMakeFiles/cpr.dir/all' failed
        make[1]: *** [cpr/CMakeFiles/cpr.dir/all] Error 2
        Makefile:129: recipe for target 'all' failed
        make: *** [all] Error 2

Probably some dependency to `curl-dev` is missing. [`bagel_package_set` lists `curl`.](https://github.com/dfki-ric/bagel_package_set/blob/master/libs.autobuild#L14)